### PR TITLE
Add ids to events if not specified in events.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1920,6 +1920,11 @@
         "@types/react": "*"
       }
     },
+    "@types/shortid": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/shortid/-/shortid-0.0.29.tgz",
+      "integrity": "sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps="
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -8666,6 +8671,11 @@
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "optional": true
     },
+    "nanoid": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -11894,6 +11904,14 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+    },
+    "shortid": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "requires": {
+        "nanoid": "^2.1.0"
+      }
     },
     "side-channel": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "@types/node": "^14.0.13",
     "@types/react": "^16.9.36",
     "@types/react-dom": "^16.9.8",
+    "@types/shortid": "0.0.29",
     "mobx": "^5.15.4",
     "mobx-react": "^6.2.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
+    "shortid": "^2.2.15",
     "typescript": "^3.9.5"
   },
   "scripts": {

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -50,7 +50,7 @@ export const Timeline = (props: TimelineProps) => {
          {() => <div className="timeline">
             <TimelineHeader resultCount={eventStore.filteredEvents.length} />
             {eventStore.filteredEvents.map((event) => (
-               <div className="timeline-row">
+               <div className="timeline-row" key={event.id}>
                   <Typography variant="h6">{event.date}</Typography>
                   <Grid container spacing={4}>
                      <Grid item>
@@ -58,7 +58,7 @@ export const Timeline = (props: TimelineProps) => {
                      </Grid>
                      {event.relatedEvents &&
                         event.relatedEvents.map((relatedEvent) => (
-                           <Grid item>
+                           <Grid item key={relatedEvent.id}>
                               <TimelineEvent event={relatedEvent} />
                            </Grid>
                         ))}

--- a/src/models/timeline-event.ts
+++ b/src/models/timeline-event.ts
@@ -1,4 +1,5 @@
 export interface TimelineEventData {
+   id: string;
    city: string;
    date: string;
    description: string;

--- a/src/stores/event-store.ts
+++ b/src/stores/event-store.ts
@@ -1,30 +1,21 @@
 import { action, computed, observable } from 'mobx';
+import shortid from 'shortid';
 
 import { TimelineEventData } from '../models/timeline-event';
 
 // TODO: When there is a real database storing events, they should
 // have ids by default. For now, generate hashes of objects if there
 // is no id.
-function rawEventToEvent(rawEvents: any[]): TimelineEventData[] {
-   const stringHash = (s: string) => {
-      let hash = 0, i, chr;
-      for (i = 0; i < s.length; i++) {
-         chr   = s.charCodeAt(i);
-         hash  = ((hash << 5) - hash) + chr;
-         hash |= 0; // Convert to 32bit integer
-      }
-      return JSON.stringify(hash);
-   };
-
-   return rawEvents.map((rawEvent) => {
-      return Object.assign({}, rawEvent, {
-         id: rawEvent.id || stringHash(JSON.stringify(rawEvent)),
-         relatedEvents: rawEvent.relatedEvents && rawEventToEvent(rawEvent.relatedEvents),
+function addIds(events: any[]): TimelineEventData[] {
+   return events.map((event) => {
+      return Object.assign({}, event, {
+         id: event.id || shortid.generate(),
+         relatedEvents: event.relatedEvents && addIds(event.relatedEvents),
       });
    });
 }
 
-const events = rawEventToEvent(require('../events.json'));
+const events = addIds(require('../events.json'));
 
 export class EventStore {
    @observable searchText: string = '';

--- a/src/stores/event-store.ts
+++ b/src/stores/event-store.ts
@@ -1,7 +1,30 @@
 import { action, computed, observable } from 'mobx';
 
 import { TimelineEventData } from '../models/timeline-event';
-const events = require('../events.json');
+
+// TODO: When there is a real database storing events, they should
+// have ids by default. For now, generate hashes of objects if there
+// is no id.
+function rawEventToEvent(rawEvents: any[]): TimelineEventData[] {
+   const stringHash = (s: string) => {
+      let hash = 0, i, chr;
+      for (i = 0; i < s.length; i++) {
+         chr   = s.charCodeAt(i);
+         hash  = ((hash << 5) - hash) + chr;
+         hash |= 0; // Convert to 32bit integer
+      }
+      return JSON.stringify(hash);
+   };
+
+   return rawEvents.map((rawEvent) => {
+      return Object.assign({}, rawEvent, {
+         id: rawEvent.id || stringHash(JSON.stringify(rawEvent)),
+         relatedEvents: rawEvent.relatedEvents && rawEventToEvent(rawEvent.relatedEvents),
+      });
+   });
+}
+
+const events = rawEventToEvent(require('../events.json'));
 
 export class EventStore {
    @observable searchText: string = '';


### PR DESCRIPTION
Eventually when there is a database to store and query events,
they will already have ids. For now, populate ids using the object
hash to silence React warnings about missing key= props on child
components.